### PR TITLE
fix: rename helm chart from dwmkerr-starter-kit to ark-demo

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: Package and push Helm chart
         run: |
           helm package ./chart
-          helm push dwmkerr-starter-kit-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
+          helm push ark-demo-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/${{ github.repository_owner }}/charts
 
   release-mcp-servers:
     name: Release MCP Server

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 help: # show help for each recipe
 	@grep -E '^[a-zA-Z0-9 -]+:.*#' Makefile | sort | while read -r l; do printf "\033[1;32m$$(echo $$l | cut -f 1 -d':')\033[00m:$$(echo $$l | cut -f 2- -d'#')\n"; done
 
-CHART_NAME := dwmkerr-starter-kit
+CHART_NAME := ark-demo
 CHART_PATH := ./chart
 NAMESPACE ?= default
 
@@ -42,7 +42,7 @@ uninstall-all: uninstall # uninstall all resources including internal tools
 .PHONY: status
 status: # show deployment status
 	helm status $(CHART_NAME) --namespace $(NAMESPACE)
-	kubectl get models,secrets -l ark.mckinsey.com/service=dwmkerr-starter-kit -n $(NAMESPACE)
+	kubectl get models,secrets -l ark.mckinsey.com/service=ark-demo -n $(NAMESPACE)
 
 .PHONY: template
 template: # render chart templates to see what would be created

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This demo kit includes Models, Agents, Agents-as-Tools (sometimes called "Sub-ag
 Install via Helm:
 
 ```bash
-helm upgrade --install dwmkerr-starter-kit oci://ghcr.io/dwmkerr/charts/dwmkerr-starter-kit \
+helm upgrade --install ark-demo oci://ghcr.io/dwmkerr/charts/ark-demo \
     --set models.anthropic.apiKey="your-key" \
     --set models.gemini.apiKey="your-key"
 ```

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -1,11 +1,11 @@
 apiVersion: v2
-name: dwmkerr-starter-kit
+name: ark-demo
 description: A Helm chart for dwmkerr's Ark demo models and agents
 type: application
 version: 0.1.4
 appVersion: 0.1.4
 annotations:
-  ark.mckinsey.com/service: dwmkerr-starter-kit
+  ark.mckinsey.com/service: ark-demo
 dependencies:
   - name: ai-developer-guide-mcp
     version: '>=0.1.0'

--- a/chart/templates/01-secrets.yaml
+++ b/chart/templates/01-secrets.yaml
@@ -8,7 +8,7 @@ kind: Secret
 metadata:
   name: anthropic-api-key
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/claude.png"
 type: Opaque
@@ -26,7 +26,7 @@ kind: Secret
 metadata:
   name: gemini-model-token
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/gemini.png"
 type: Opaque
@@ -44,7 +44,7 @@ kind: Secret
 metadata:
   name: dwmkerr-azure-openai-secret
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
 type: Opaque
 data:
   apiKey: {{ .Values.models.azureOpenAI.apiKey | b64enc | quote }}
@@ -60,7 +60,7 @@ kind: Secret
 metadata:
   name: openai-api-key
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
 type: Opaque
 data:
   apiKey: {{ .Values.models.openai.apiKey | b64enc | quote }}
@@ -79,7 +79,7 @@ kind: Secret
 metadata:
   name: dwmkerr-bedrock-secret
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/aws.png"
 type: Opaque

--- a/chart/templates/02-models.yaml
+++ b/chart/templates/02-models.yaml
@@ -7,7 +7,7 @@ kind: Model
 metadata:
   name: {{ .name }}
   labels:
-    {{- include "dwmkerr-starter-kit.labels" $ | nindent 4 }}
+    {{- include "ark-demo.labels" $ | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/claude.png"
 spec:
@@ -36,7 +36,7 @@ kind: Model
 metadata:
   name: {{ .name }}
   labels:
-    {{- include "dwmkerr-starter-kit.labels" $ | nindent 4 }}
+    {{- include "ark-demo.labels" $ | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/gemini.png"
 spec:
@@ -65,7 +65,7 @@ kind: Model
 metadata:
   name: {{ .name }}
   labels:
-    {{- include "dwmkerr-starter-kit.labels" $ | nindent 4 }}
+    {{- include "ark-demo.labels" $ | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/azure.png"
 spec:
@@ -96,7 +96,7 @@ kind: Model
 metadata:
   name: {{ .name }}
   labels:
-    {{- include "dwmkerr-starter-kit.labels" $ | nindent 4 }}
+    {{- include "ark-demo.labels" $ | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/openai-blue.png"
 spec:
@@ -125,7 +125,7 @@ kind: Model
 metadata:
   name: {{ .name }}
   labels:
-    {{- include "dwmkerr-starter-kit.labels" $ | nindent 4 }}
+    {{- include "ark-demo.labels" $ | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/aws.png"
 spec:

--- a/chart/templates/03-tools/call-shell-subagent-tool.yaml
+++ b/chart/templates/03-tools/call-shell-subagent-tool.yaml
@@ -5,7 +5,7 @@ kind: Tool
 metadata:
   name: call-shell-subagent
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
 spec:
   type: agent
   description: Execute shell commands via specialized shell operations agent

--- a/chart/templates/04-agents/code-reviewer-agent.yaml
+++ b/chart/templates/04-agents/code-reviewer-agent.yaml
@@ -4,7 +4,7 @@ kind: Agent
 metadata:
   name: code-reviewer
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/claude.png"
 spec:

--- a/chart/templates/04-agents/github-agent.yaml
+++ b/chart/templates/04-agents/github-agent.yaml
@@ -5,7 +5,7 @@ kind: Agent
 metadata:
   name: github-agent
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/github.png"
 spec:

--- a/chart/templates/04-agents/lead-software-engineer-agent.yaml
+++ b/chart/templates/04-agents/lead-software-engineer-agent.yaml
@@ -4,7 +4,7 @@ kind: Agent
 metadata:
   name: lead-software-engineer
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/claude.png"
 spec:

--- a/chart/templates/04-agents/planner-agent.yaml
+++ b/chart/templates/04-agents/planner-agent.yaml
@@ -4,7 +4,7 @@ kind: Agent
 metadata:
   name: planner
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
   annotations:
     ark.mckinsey.com/dashboard-icon: "/icons/claude.png"
 spec:

--- a/chart/templates/04-agents/shell-subagent.yaml
+++ b/chart/templates/04-agents/shell-subagent.yaml
@@ -5,7 +5,7 @@ kind: Agent
 metadata:
   name: shell-subagent
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
 spec:
   description: Specialized shell operations agent that executes commands safely
   tools:

--- a/chart/templates/04-agents/team-leader-agent.yaml
+++ b/chart/templates/04-agents/team-leader-agent.yaml
@@ -4,7 +4,7 @@ kind: Agent
 metadata:
   name: team-leader
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
 spec:
   description: Team leader and strategic planner who coordinates work distribution among team members
   # Uses default model configured in the system

--- a/chart/templates/05-teams/coding-team.yaml
+++ b/chart/templates/05-teams/coding-team.yaml
@@ -4,7 +4,7 @@ kind: Team
 metadata:
   name: coding-team
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
 spec:
   description: Collaborative team with planner and code reviewer working sequentially on development tasks
   members:

--- a/chart/templates/05-teams/engineering-team.yaml
+++ b/chart/templates/05-teams/engineering-team.yaml
@@ -4,7 +4,7 @@ kind: Team
 metadata:
   name: engineering-team
   labels:
-    {{- include "dwmkerr-starter-kit.labels" . | nindent 4 }}
+    {{- include "ark-demo.labels" . | nindent 4 }}
 spec:
   description: Engineering team with planner and lead software engineer using selector strategy
   strategy: selector

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -1,7 +1,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "dwmkerr-starter-kit.name" -}}
+{{- define "ark-demo.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
@@ -10,7 +10,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "dwmkerr-starter-kit.fullname" -}}
+{{- define "ark-demo.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -26,27 +26,27 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "dwmkerr-starter-kit.chart" -}}
+{{- define "ark-demo.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Common labels
 */}}
-{{- define "dwmkerr-starter-kit.labels" -}}
-helm.sh/chart: {{ include "dwmkerr-starter-kit.chart" . }}
-{{ include "dwmkerr-starter-kit.selectorLabels" . }}
+{{- define "ark-demo.labels" -}}
+helm.sh/chart: {{ include "ark-demo.chart" . }}
+{{ include "ark-demo.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-ark.mckinsey.com/service: dwmkerr-starter-kit
+ark.mckinsey.com/service: ark-demo
 {{- end }}
 
 {{/*
 Selector labels
 */}}
-{{- define "dwmkerr-starter-kit.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "dwmkerr-starter-kit.name" . }}
+{{- define "ark-demo.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ark-demo.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
## Summary
- Renamed helm chart from `dwmkerr-starter-kit` to `ark-demo` to match repository name
- Updated all references across chart templates, Makefile, README, and CI/CD workflow
- Breaking change: existing deployments will need to be reinstalled