### PR TITLE
feat: add Notion MCP + note-taker agent and Claude Agent SDK developer agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ The following agents will be deployed:
 | `github-agent` | `mcpServers.github.enabled` | GitHub specialist for repository management, issues, pull requests, workflows, and security | All GitHub MCP tools |
 | `shell-subagent` | `mcpServers.shell.enabled` | Specialized shell operations agent that executes commands safely (used as agent-as-tool) | Shell MCP tool |
 | `note-taker` | `mcpServers.notion.enabled` | Notion-backed shared notes; requires an Anthropic-capable model — defaults to `claude-4-opus` | All 14 Notion MCP tools |
+| `claude-developer` | `models.anthropic.native` | Software developer powered by the Claude Agent SDK; built-in Read/Write/Edit/Bash/Grep/Glob tools in an isolated session directory | Claude Agent SDK built-ins |
+| `claude-developer-critic` | `models.anthropic.native` | Critic that reviews `claude-developer` output via the Claude Agent SDK | Claude Agent SDK built-ins (read-only use) |
 
 ### Teams
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The following agents will be deployed:
 | `lead-software-engineer` | Always | Lead software engineer with access to development tools, GitHub operations, and best practices | Conditional: GitHub tools, AI Developer Guide tools, shell subagent |
 | `github-agent` | `mcpServers.github.enabled` | GitHub specialist for repository management, issues, pull requests, workflows, and security | All GitHub MCP tools |
 | `shell-subagent` | `mcpServers.shell.enabled` | Specialized shell operations agent that executes commands safely (used as agent-as-tool) | Shell MCP tool |
+| `note-taker` | `mcpServers.notion.enabled` | Notion-backed shared notes; requires an Anthropic-capable model — defaults to `claude-4-opus` | All 14 Notion MCP tools |
 
 ### Teams
 
@@ -131,6 +132,7 @@ MCP servers can be enabled via Helm dependencies in `custom-values.yaml`:
 | [AI Developer Guide](https://github.com/dwmkerr/ai-developer-guide) | `mcpServers.aiDeveloperGuide.enabled` | `helm install ai-developer-guide-mcp oci://ghcr.io/dwmkerr/charts/ai-developer-guide-mcp` |
 | AWS Knowledge | `mcpServers.awsKnowledge.enabled` | Remote MCP server (no install needed) |
 | Microsoft Learn | `mcpServers.microsoftLearn.enabled` | Remote MCP server (no install needed) |
+| Notion | `mcpServers.notion.enabled` | Remote MCP server; populate token with `ark mcp auth login notion` after install |
 
 Set to `true` in `custom-values.yaml` and run `make install`.
 

--- a/chart/templates/02-models.yaml
+++ b/chart/templates/02-models.yaml
@@ -30,6 +30,43 @@ spec:
 {{- end }}
 {{- end }}
 
+{{- /*
+Native Anthropic-provider Model variants (suffix "-native") for executors
+that require provider: anthropic — notably executor-claude-agent-sdk, which
+uses the Claude Agent SDK directly and rejects openai-shaped Model CRDs.
+Emitted alongside the openai-compat shape above so existing agents keep
+working; only opt-in agents reference the -native variants.
+*/ -}}
+{{- if and .Values.models.anthropic.enabled .Values.models.anthropic.native }}
+{{- range .Values.models.anthropic.models }}
+{{- if not (and (eq .name "default") $.Values.skipDefaultModel) }}
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Model
+metadata:
+  name: {{ .name }}-native
+  labels:
+    {{- include "ark-demo.labels" $ | nindent 4 }}
+  annotations:
+    ark.mckinsey.com/dashboard-icon: "/icons/claude.png"
+spec:
+  provider: anthropic
+  model:
+    value: {{ .model }}
+  pollInterval: 1m
+  config:
+    anthropic:
+      baseUrl:
+        value: "https://api.anthropic.com"
+      apiKey:
+        valueFrom:
+          secretKeyRef:
+            name: anthropic-api-key
+            key: apiKey
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- if .Values.models.gemini.enabled }}
 {{- range .Values.models.gemini.models }}
 {{- if not (and (eq .name "default") $.Values.skipDefaultModel) }}

--- a/chart/templates/04-agents/claude-developer-agents.yaml
+++ b/chart/templates/04-agents/claude-developer-agents.yaml
@@ -1,0 +1,56 @@
+{{- /*
+claude-developer + claude-developer-critic agents.
+
+Use executor-claude-agent-sdk (installed by `make install` via
+`ark install marketplace/executors/executor-claude-agent-sdk`). The
+executor talks to Anthropic's native API and rejects openai-shape Model
+CRDs, so the agents reference the "-native" Model variants emitted by
+chart/templates/02-models.yaml when models.anthropic.native is true.
+
+Gated on models.anthropic.native so that disabling the native variant
+also hides these agents — avoids dangling references to missing Models.
+*/ -}}
+{{- if and .Values.models.anthropic.enabled .Values.models.anthropic.native }}
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: claude-developer
+  labels:
+    {{- include "ark-demo.labels" . | nindent 4 }}
+  annotations:
+    ark.mckinsey.com/dashboard-icon: "/icons/claude.png"
+spec:
+  description: Software developer powered by the Claude Agent SDK with built-in filesystem and shell tools.
+  executionEngine:
+    name: executor-claude-agent-sdk
+  modelRef:
+    name: claude-4-opus-native
+  prompt: |
+    You are a pragmatic senior software developer. You have access to filesystem
+    tools (Read, Write, Edit, Grep, Glob) and a shell (Bash) within an isolated
+    session directory. Implement what is requested with minimal, correct changes.
+    Prefer reading existing code before modifying it. Be concise in explanations.
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: claude-developer-critic
+  labels:
+    {{- include "ark-demo.labels" . | nindent 4 }}
+  annotations:
+    ark.mckinsey.com/dashboard-icon: "/icons/claude.png"
+spec:
+  description: Critical reviewer of code produced by the claude-developer agent, powered by the Claude Agent SDK.
+  executionEngine:
+    name: executor-claude-agent-sdk
+  modelRef:
+    name: claude-4-opus-native
+  prompt: |
+    You are a rigorous code reviewer. You have access to filesystem tools
+    (Read, Grep, Glob) and a shell (Bash) within an isolated session directory.
+    Review the work of the claude-developer agent: identify bugs, missing edge
+    cases, security issues, unnecessary complexity, and deviations from the
+    request. Be direct and specific. Cite file paths and line numbers. If the
+    work is good, say so plainly.
+{{- end }}

--- a/chart/templates/04-agents/note-taker.yaml
+++ b/chart/templates/04-agents/note-taker.yaml
@@ -1,0 +1,69 @@
+{{- /*
+Note-taker agent — Notion-backed shared notes.
+
+Model selection: defaults to claude-4-opus. Empirically, Notion's search
+tool description has examples + "don't combine X" warnings that
+stronger tool-followers (Claude Sonnet/Opus) heed. Weaker or older
+models (e.g. azure-gpt-4.1, gemini-2-5-flash-lite, claude-3-5-haiku
+variants) tend to over-filter — they chain get-teams -> search with a
+teamspace_id, use literal "*" as the query, and omit the required
+`filters: {}` field, returning empty results against a workspace that
+has plenty of pages. If you swap the model to one of those, expect to
+either tighten the prompt or accept worse tool-call fidelity.
+
+All 14 Notion MCP tools are wired so the agent can both read and
+write notes (search, fetch, get-comments/teams/users, create-pages,
+update-page, create-comment, duplicate-page, move-pages, plus the
+database/view/data-source admin tools). Trim this list if your
+operator persona is read-only.
+*/ -}}
+{{- if and .Values.mcpServers .Values.mcpServers.notion .Values.mcpServers.notion.enabled }}
+---
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: Agent
+metadata:
+  name: note-taker
+  labels:
+    {{- include "ark-demo.labels" . | nindent 4 }}
+  annotations:
+    ark.mckinsey.com/dashboard-icon: "/icons/notion.png"
+spec:
+  description: Notion-backed shared notes; reads and writes pages, comments, and views.
+  modelRef:
+    name: {{ (.Values.agents | default dict).noteTaker | default dict | dig "model" "claude-4-opus" }}
+  prompt: |
+    You use the 'notion' MCP tools to find, read, and write notes in
+    Notion on behalf of the user. Search with natural-language queries
+    rather than wildcards. Do not narrow searches by teamspace unless
+    the user explicitly names a team. Always pass `filters: {}` when
+    the search tool requires it, even if you have nothing to filter.
+  tools:
+    - name: notion-notion-search
+      type: mcp
+    - name: notion-notion-fetch
+      type: mcp
+    - name: notion-notion-get-comments
+      type: mcp
+    - name: notion-notion-get-teams
+      type: mcp
+    - name: notion-notion-get-users
+      type: mcp
+    - name: notion-notion-create-pages
+      type: mcp
+    - name: notion-notion-update-page
+      type: mcp
+    - name: notion-notion-create-comment
+      type: mcp
+    - name: notion-notion-duplicate-page
+      type: mcp
+    - name: notion-notion-move-pages
+      type: mcp
+    - name: notion-notion-create-database
+      type: mcp
+    - name: notion-notion-create-view
+      type: mcp
+    - name: notion-notion-update-view
+      type: mcp
+    - name: notion-notion-update-data-source
+      type: mcp
+{{- end }}

--- a/chart/templates/06-mcp-servers/notion-mcp.yaml
+++ b/chart/templates/06-mcp-servers/notion-mcp.yaml
@@ -1,0 +1,45 @@
+{{- /*
+Notion MCPServer plus shell token Secret.
+
+The Secret ships empty by design. No chart packages OAuth tokens — the
+operator runs `ark mcp auth login notion` post-install to populate
+`data.token` via OAuth device flow. The shell exists in-chart so a fresh
+`helm install` provides a stable target for the CLI patch.
+
+The `ark.mckinsey.com/mcp-token-secret: "true"` label opts the Secret into
+the Ark controller's Secret watch. With the label, MCPServer state
+reconciles immediately when the CLI patches the token. Without it,
+reconciliation still happens on the next periodic resync.
+
+Temporary home: Notion will move into the Ark marketplace
+(mckinsey/agents-at-scale-marketplace) once that chart is published. Demo
+and dogfooding live here until then.
+*/ -}}
+{{- if and .Values.mcpServers .Values.mcpServers.notion .Values.mcpServers.notion.enabled }}
+apiVersion: ark.mckinsey.com/v1alpha1
+kind: MCPServer
+metadata:
+  name: notion
+  annotations:
+    ark.mckinsey.com/dashboard-icon: "/icons/notion.png"
+spec:
+  address:
+    value: "https://mcp.notion.com/mcp"
+  authorization:
+    tokenSecretRef:
+      name: {{ .Values.mcpServers.notion.secretName | default "notion-oauth" }}
+  pollInterval: "30s"
+  timeout: "1m"
+  transport: http
+  description: "Notion MCP server"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.mcpServers.notion.secretName | default "notion-oauth" }}
+  labels:
+    {{- include "ark-demo.labels" . | nindent 4 }}
+    ark.mckinsey.com/mcp-token-secret: "true"
+type: Opaque
+data: {}
+{{- end }}

--- a/custom-values.template.yaml
+++ b/custom-values.template.yaml
@@ -6,6 +6,10 @@ models:
     enabled: true
     apiKey: ""  # REQUIRED: Set your Anthropic API key (sk-ant-...)
     baseUrl: "https://api.anthropic.com/v1/"
+    # Emit native provider: anthropic Model variants (suffix "-native") for
+    # executors that require it (e.g. executor-claude-agent-sdk used by the
+    # claude-developer agents). Adds Models alongside the openai-compat ones.
+    native: false
     models:
       - name: claude-3-5-sonnet
         model: claude-3-5-sonnet-20241022

--- a/custom-values.template.yaml
+++ b/custom-values.template.yaml
@@ -90,6 +90,18 @@ mcpServers:
   microsoftLearn:
     enabled: true
 
+  # Notion MCP server - token populated via `ark mcp auth login notion`
+  notion:
+    enabled: false
+    # secretName: notion-oauth  # Override the shell Secret name if needed
+
+# Agent configuration
+agents:
+  noteTaker:
+    # Override the model the note-taker uses. Default: claude-4-opus.
+    # See chart/templates/04-agents/note-taker.yaml for the rationale.
+    # model: claude-4-opus
+
 # Subchart configuration
 ai-developer-guide-mcp:
   mcpServer:


### PR DESCRIPTION
## Summary
- Adds Notion remote MCP server gated on `mcpServers.notion.enabled`; OAuth token populated post-install via `ark mcp auth login notion`. Chart ships an empty Secret labelled `ark.mckinsey.com/mcp-token-secret` so the controller reconciles immediately on patch.
- Adds `note-taker` agent wired to all 14 Notion MCP tools; defaults to `claude-4-opus` (weaker models over-filter Notion's search tool — rationale captured in template).
- Adds native Anthropic Model variants (suffix `-native`) emitted alongside the openai-compat shape when `models.anthropic.native=true`. Required because `executor-claude-agent-sdk` rejects openai-shape Model CRDs.
- Adds `claude-developer` + `claude-developer-critic` agents using `executor-claude-agent-sdk` and referencing `claude-4-opus-native`. Gated on `models.anthropic.native` so disabling the variant also hides the agents.
- Executor itself already installed via `ark install marketplace/executors/executor-claude-agent-sdk` in the Makefile install target.