### PR TITLE
feat: add demo team to access allowlist with nuanced RBAC

### DIFF
--- a/terraform/environments/demo/demo-users.yaml
+++ b/terraform/environments/demo/demo-users.yaml
@@ -10,5 +10,20 @@
 # dashboard loads but every resource call is forbidden), so this list is the
 # access gate.
 users:
+  # admins — full control of Ark resources in the tenant namespace
   - github: dwmkerr
     role: admin
+  - github: Nab-0
+    role: admin
+  # editors — viewer + run queries + edit agents/teams/tools
+  - github: skazinka
+    role: editor
+  - github: amanvr
+    role: editor
+  - github: CDimonaco
+    role: editor
+  # viewers — read-only
+  - github: skokaina
+    role: viewer
+  - github: cm94242
+    role: viewer


### PR DESCRIPTION
## Summary
- Add active ark team to the demo allowlist (`terraform/environments/demo/demo-users.yaml`)
- Role spread across all tiers to demo each preflight outcome:
  - **admin**: dwmkerr, Nab-0
  - **editor**: skazinka, amanvr, CDimonaco
  - **viewer**: skokaina, cm94242
- `dwmkerr-agent` deliberately excluded → demos the AccessDenied state for an authenticated user with no RoleBinding

Merging triggers the gated terraform apply, which binds these users and (via current image-override vars) rolls the logout-fix dashboard image.