### PR TITLE
fix(infra): pin demo node to its launch AMI to stop state-wipes

### DIFF
--- a/terraform/modules/compute/main.tf
+++ b/terraform/modules/compute/main.tf
@@ -107,6 +107,15 @@ resource "aws_instance" "node" {
   })
 
   tags = { Name = "${var.name}-node" }
+
+  # The AMI is resolved from the al2023 "latest" SSM alias, which moves whenever
+  # AWS publishes a new image. Without this, the next apply after an AMI release
+  # replaces the node — a fresh root volume that reinstalls k3s and wipes all
+  # cluster state. Pin the running node to its launch AMI; rebuilds from scratch
+  # (taint/replace) still pick up the latest.
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }
 
 resource "aws_eip_association" "node" {


### PR DESCRIPTION
## Summary
- The demo k3s node's AMI resolves from the al2023 `latest` SSM alias, which moves whenever AWS publishes a new image. Combined with `user_data_replace_on_change`, the next `terraform apply` after an AMI release **replaced the instance** — a fresh root volume that reinstalls k3s and **wipes all cluster state** (ark, cert-manager, dex, RBAC, tenant resources). This recurred several times mid-testing.
- Add `lifecycle { ignore_changes = [ami] }` to the node so AMI drift no longer triggers a replace. The running node keeps its state across applies; intentional rebuilds (taint/replace) still pick up the latest AMI.

Evidence: node `i-09ea…` (state-wipe #1) and `i-0c380…` (launched on the apply that wiped it again, on-demand/`use_spot=false`, only the latest-AMI input could have changed) confirm replacement-on-AMI-drift, not reboots — EBS root survives reboots.