### PR TITLE
fix(demo): refresh Anthropic model ids to current snapshots

### DIFF
--- a/terraform/environments/demo/ark-demo-values.yaml
+++ b/terraform/environments/demo/ark-demo-values.yaml
@@ -9,19 +9,19 @@ models:
     apiKey: "" # injected via set_sensitive
     baseUrl: "https://api.anthropic.com/v1/"
     models:
-      # NOTE: the claude-3-5-*-20241022 snapshots are retired at Anthropic and
-      # 404 the model probe. Use current Claude 4 ids. claude-opus-4-20250514 is
-      # verified Available against this endpoint.
+      # Anthropic retires dated snapshots, which then 404 the model probe and
+      # break every agent. Use current ids (verified 200 against this endpoint
+      # via GET /v1/models + a chat/completions probe on 2026-06-16).
       #
       # 'default' is the model agents fall back to (planner, team-leader,
       # lead-software-engineer all reference it).
       - name: default
-        model: claude-opus-4-20250514
+        model: claude-opus-4-8
       - name: claude-sonnet-4
-        model: claude-sonnet-4-20250514
+        model: claude-sonnet-4-6
       # Referenced by the code-reviewer agent.
       - name: claude-4-opus
-        model: claude-opus-4-20250514
+        model: claude-opus-4-8
 
   # Disabled for now — using anthropic keys only. Re-enable with valid keys.
   gemini:


### PR DESCRIPTION
## Summary
- Demo Anthropic models pointed at retired snapshots (`claude-opus-4-20250514`, `claude-sonnet-4-20250514`) → 404 `model not_found` at Anthropic → every agent query failed (the chat 'stream error' the team hit).
- Updated to current ids, verified 200 against the live endpoint (`GET /v1/models` + a `/v1/chat/completions` probe with the demo key): `default` + `claude-4-opus` → `claude-opus-4-8`, `claude-sonnet-4` → `claude-sonnet-4-6`.

Merging triggers the gated apply (updates the Model resources).