### PR TITLE
fix(demo): grant list/get on core services to demo roles

### DIFF
--- a/terraform/modules/ark-auth/rbac.tf
+++ b/terraform/modules/ark-auth/rbac.tf
@@ -40,7 +40,7 @@ resource "kubernetes_role" "ark_viewer" {
 
   rule {
     api_groups = [""]
-    resources  = ["pods", "pods/log", "events"]
+    resources  = ["pods", "pods/log", "events", "services"]
     verbs      = ["get", "list", "watch"]
   }
 }
@@ -63,7 +63,7 @@ resource "kubernetes_role" "ark_editor" {
 
   rule {
     api_groups = [""]
-    resources  = ["pods", "pods/log", "events"]
+    resources  = ["pods", "pods/log", "events", "services"]
     verbs      = ["get", "list", "watch"]
   }
 
@@ -97,7 +97,7 @@ resource "kubernetes_role" "ark_admin" {
 
   rule {
     api_groups = [""]
-    resources  = ["pods", "pods/log", "events", "configmaps", "secrets"]
+    resources  = ["pods", "pods/log", "events", "configmaps", "secrets", "services"]
     verbs      = ["get", "list", "watch"]
   }
 }


### PR DESCRIPTION
## Summary
- The dashboard lists core k8s Services (service discovery / chat broker-health check) as the impersonated user, but the demo roles didn't grant core `services` → 403 → 500 → 'API request failed' in chat.
- Add `services` (get/list/watch) to ark-viewer/editor/admin. Scoped to the tenant namespace via the existing RoleBindings.